### PR TITLE
Update ndwi_labels.py , change the value of clip and no data parameters

### DIFF
--- a/ndwi_labels.py
+++ b/ndwi_labels.py
@@ -44,44 +44,45 @@ def clip_shp(path_to_shp, boundary_geojson):
     out_path = path_name + shp_base + "_clipped.shp"
     shp_clipped.to_file(out_path)
 
-
 def get_ndwi_label(image_path, points_path, ksize = 100):
     # establish the ndwi calculation and copy metadata
     with rio.open(image_path, driver='GTiff') as src_raster:
-        green = src_raster.read(2).astype(np.float32)
-        nir_num = src_raster.count  # adjusting NIR band to 4 or 5 band images
-        nir = src_raster.read(nir_num).astype(np.float32)
-        np.seterr(divide='ignore', invalid='ignore')
-        ndwi = (green - nir) / (green + nir)
-        ndwi[np.isnan(ndwi)] = 0
         
-        print("Green max: {}".format(green.max()))
-        print("NIR max: {}".format(nir.max()))
-        print("NDWI max: {}".format(np.nanmax(ndwi)))
-        print("NDWI min: {}".format(np.nanmin(ndwi)))
-        ndwi_profile = src_raster.profile
+        green = src_raster.read(2).astype(np.float32) # Get the green band 
+        nir_num = src_raster.count  # Adjusting NIR band to 4 or 5 band images
+        nir = src_raster.read(nir_num).astype(np.float32) # Get NIR band
+        
+        np.seterr(divide='ignore', invalid='ignore')
+        
+        ndwi = (green - nir) / (green + nir)  # NDWI equation
+        ndwi[np.isnan(ndwi)] = 0 # Sets any NaN values in the NDWI array to 0. (Dividing by zero => Nan Pixels)
+        ndwi_profile = src_raster.profile # Copies the image profile (metadata).
+
+        
         # blank label layer
         label = np.zeros((src_raster.height, src_raster.width)).astype(np.uint8)
-        agg_mask = np.zeros((src_raster.height, src_raster.width)).astype(np.uint8)
         src_CRS = src_raster.crs
-        # getting pixel size for correct calculation of buffer
-        pixel_size = abs(src_raster.transform[0])
+        # Getting pixel size for correct calculation of buffer.
+        # This value express spatial resolution.
+        pixel_size = abs(src_raster.transform[0]) 
+        
         figs, ax = plt.subplots(figsize=(12, 8))
         show(ndwi, transform=src_raster.transform, ax=ax, cmap='gray')
 
     # preparing points for creating label masks
     points_shp = gpd.read_file(points_path)
     points_geom = points_shp.geometry
-    points_geom = points_geom.set_crs(epsg=4326)
-    points_geom = points_geom.to_crs(src_CRS)
+    points_geom = points_geom.set_crs(epsg=4326) # Set CRS to WGS84
+    points_geom = points_geom.to_crs(src_CRS) # Convert CRS to match the raster
 
-    # creating a holder for Otsu's threshold values
-    otsu_thresholds = []
-    skipped = 0
+
+    otsu_thresholds_clipped = [] # Creating a holder for Otsu's threshold values for clipped images
+    skipped = 0 # Counter for skipped windows (Less than 201*201)
     
     # processing each point found
     for multipoint in points_geom:
         for point in multipoint.geoms:
+            # Create a buffer around the point
             buffer = point.buffer(ksize * pixel_size, cap_style=3)
             buffer_series = gpd.GeoSeries(buffer)
             buffer_series.exterior.plot(ax=ax, color='red', linewidth=1)
@@ -92,52 +93,53 @@ def get_ndwi_label(image_path, points_path, ksize = 100):
                 with memfile.open(**ndwi_profile) as mem_data:
                     mem_data.write_band(1, ndwi)
                 with memfile.open() as dataset:
-                    out_image, out_transform = mask(dataset, shapes=[buffer], nodata=0, crop=False)
-                    temp_mask = np.ma.getmaskarray(out_image)
-                    #plt.imshow(temp_mask[0])
-                    #plt.show()
+                    
+                    out_image, out_transform = mask(dataset, shapes=[buffer], nodata=-1, crop=False)
                     out_image = out_image[0]
                     out_image = (out_image * 127) + 128
                     out_image = out_image.astype(np.uint8)
-                    #plt.imshow(out_image)
-                    #plt.show()
                     
-                    if out_image.shape[0] < 200 or out_image.shape[1] < 200:
-                        skipped += 1
-                        continue
-                    else:
-                        otsu_threshold, image_result = cv2.threshold(out_image, 0, 1, cv2.THRESH_BINARY + cv2.THRESH_OTSU, )
-                        otsu_thresholds.append(otsu_threshold)
-                        agg_mask = (agg_mask | np.ma.getmask(out_image).astype(np.uint8)).astype(np.uint8)
-                        threshold_window = np.where(out_image >= otsu_threshold, 1, 0).astype(np.uint8)
-                        label = label | threshold_window.astype(np.uint8)
-    print("Total number of valid thresholds: {}".format(len(otsu_thresholds)))
+                    out_image_clipped, out_transform_clipped = mask(dataset, shapes=[buffer], nodata=-1, crop=True)
+                    out_image_clipped = out_image_clipped[0]
+                    out_image_clipped = (out_image_clipped * 127) + 128
+                    out_image_clipped = out_image_clipped.astype(np.uint8)
+                
+                # Skip buffering windows that part or all of it out of NDWI image
+                if out_image_clipped.shape[0] < 200 or out_image_clipped.shape[1] < 200:
+                    skipped += 1
+                    continue
+                
+                else:
+                    # Calculate otsu threshold based on clipped image
+                    threshold_clipped, image_result_clipped = cv2.threshold(out_image_clipped, 0, 1, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+                    otsu_thresholds_clipped.append(threshold_clipped)
+                    threshold_window = np.where(out_image >= threshold_clipped, 1, 0).astype(np.uint8)
+                    label = label | threshold_window.astype(np.uint8)
+                        
+    print("Green max: {}".format(green.max()))
+    print("NIR max: {}".format(nir.max()))
+    print("NDWI max: {}".format(np.nanmax(ndwi)))
+    print("NDWI min: {}".format(np.nanmin(ndwi)))
+        
+    print("Total number of valid thresholds: {}".format(len(otsu_thresholds_clipped)))
     print("Number of skipped windows: {}".format(skipped))
-    print("Actual thresholds (8-bit unsigned): \n{}".format(otsu_thresholds))
-    print("Average threshold value (8-bit unsigned): {}".format(np.mean(otsu_thresholds)))
-    print("Average threshold value (-1 to 1 NDWI range): {}".format((np.mean(otsu_thresholds) - 128) / 127))
+    print("Actual thresholds (8-bit unsigned): \n{}".format(otsu_thresholds_clipped))
+    print("Average threshold value (8-bit unsigned): {}".format(np.mean(otsu_thresholds_clipped)))
+    print("Average threshold value (-1 to 1 NDWI range): {}".format((np.mean(otsu_thresholds_clipped) - 128) / 127))
 
     print("\nLabel max: {}".format(np.nanmax(label)))
     print("Label min: {}".format(np.nanmin(label)))
     plt.imshow(label)
     plt.show()
 
-    print("\nMask max: {}".format(np.nanmax(agg_mask)))
-    print("Mask min: {}".format(np.nanmin(agg_mask)))
-    plt.imshow(agg_mask)
-    plt.show()
-
-    mean_threshold = np.mean(otsu_thresholds) + 10
+    mean_threshold = np.mean(otsu_thresholds_clipped) + 10
     ndwi_8bit = ((ndwi * 127) + 128).astype(np.uint8)
     ndwi_classified = np.where(ndwi_8bit >= mean_threshold, 1, 0)
     plt.imshow(ndwi_classified, cmap="gray")
     plt.show()
-
-
             
     points_geom.plot(ax=ax, color='blue', markersize=5)
     plt.show()
-    pass
 
 
 boundary = {'type': 'Polygon',
@@ -146,10 +148,6 @@ boundary = {'type': 'Polygon',
                              [-162.674560546875, 66.10883816429516],
                              [-162.8235626220703, 66.10883816429516], 
                              [-162.8235626220703, 66.05622435812153]]]}
-image_path = "data/369619_2016-08-29_RE1_3A_Analytic_SR_clip.tif"
-# image_path = "data/268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif"
-points_path = "data/Deering_transect_points_2016.shp"
+image_path = "D:/GSoC2024/data/input/268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif"
+points_path = "D:/GSoC2024/data/Deering2016/Deering_transect_points_2016.shp"
 get_ndwi_label(image_path, points_path)
-
-# path_to_shp = "C:\\Users\\kjcar\\Downloads\\Deering_DSAS_Calculations\\WestChukchi_exposed_STepr_rates\\WestChukchi_exposed_STepr_rates.shp"
-# clip_shp(path_to_shp, boundary)


### PR DESCRIPTION
## Changing Parameters Value:

- **clip**: Set to `True` to ensure that only the portion of the sliding window that intersects with the NDWI image is considered.
- **Sliding Window Handling**:
  - **Intersection**: Only sliding windows that intersect with the NDWI image are considered.
  - **Ignoring**: Windows that are completely outside or only partially intersecting with the image are ignored.
- **Threshold Calculation**: The threshold is calculated based on the clipped portion of the image to ensure accurate segmentation.
- **nodata**: Set to `-1` to represent pixels with no data.
- **Threshold Application**: Pixels outside the sliding window are always considered less than the threshold and are not segmented as water.

### Benefits
- **Improved Accuracy**: By clipping and only considering intersecting windows, the segmentation process becomes more precise.
- **Efficient Handling**: Avoids processing unnecessary parts of the image, leading to more efficient computations.
- **Consistent Thresholding**: Ensures that threshold calculations and applications are based on relevant image data.


 **This pull request is part of Google Summer of Code 2024.**