### PR TITLE
Improve empty search handling in DeeringAutoDownloadCode

### DIFF
--- a/DeeringAutoDownloadCode.py
+++ b/DeeringAutoDownloadCode.py
@@ -245,11 +245,19 @@ def get_images_ids(search_filter, item_type):
         auth=HTTPBasicAuth(API_KEY, ''),
         json=search_request)
     
+    if search_result.status_code != 200:
+        print(f"Error: {search_result.status_code} - {search_result.text}")
+        return []
+
     geojson = search_result.json()
+
+    if 'features' not in geojson or not geojson['features']:
+        print("Warning: No matching imagery found for the given filter.")
+        return []
+
     image_ids = [feature['id'] for feature in geojson['features']]
-    
-    print(f"Number of images available is {len(image_ids)}")
-    
+    print(f"Number of images available: {len(image_ids)}")
+
     return image_ids
 
 


### PR DESCRIPTION
# Handle empty planetary search results in get_images_ids
## Overview
This PR enhances the get_images_ids function to handle edge cases. It also checks for failed search requests (i.e non-200 status codes) and warns the user if no imagery is returned, and instead returning an empty list to avoid causing runtime errors. This makes Planet API lookups more robust and user-friendly.