### PR TITLE
Enhanced rem_winter function in DeeringAutoDownloadCode.py

### DIFF
--- a/DeeringAutoDownloadCode.py
+++ b/DeeringAutoDownloadCode.py
@@ -280,7 +280,7 @@ def get_image_date(image_id, date_format, date_length):
     
 # Remove winter image ids :
 # - Removes images taken during winter months specified by day of the year range.
-def rem_winter(ids, date_format, date_length, winter_start, winter_end):
+def rem_winter(ids, date_format, date_length, exclude_ranges):
     """
     * Args:
     - ids (list of str): List of image IDs.
@@ -291,17 +291,26 @@ def rem_winter(ids, date_format, date_length, winter_start, winter_end):
 
     * Returns:
     - list of str: List of image IDs that are not taken during the specified winter period.
+    
+    Exclude images taken during any date ranges specified in 'exclude_ranges'.
+    Each element in exclude_ranges is a tuple (start_day, end_day), where
+    'start_day' and 'end_day' are day-of-year integers (1-365 or 1-366).
     """
-    
     clear_ids = []
-    
     for image_id in ids:
         try:
-            date = get_image_date(image_id, date_format, date_length)
-            day_of_year = date.timetuple().tm_yday  # Get the day of the year from the datetime object
+            date_str = image_id[:date_length]
+            date_obj = datetime.strptime(date_str, date_format)
+            day_of_year = date_obj.timetuple().tm_yday
             
-            # Keep the image if the day is outside the winter period
-            if not (winter_start <= day_of_year or day_of_year <= winter_end):
+            # Skip this image if its day-of-year falls within any of the excluded ranges
+            skip_image = False
+            for (start_doy, end_doy) in exclude_ranges:
+                if start_doy <= day_of_year <= end_doy:
+                    skip_image = True
+                    break
+            
+            if not skip_image:
                 clear_ids.append(image_id)
         except ValueError as e:
             print(e)  # Print error if the date format does not match
@@ -424,8 +433,7 @@ date_format_dict = {
 start_date_input = "2023-08-01"
 end_date_input = "2023-08-10"
 
-winter_start_day = 290
-winter_end_day = 136
+exclude_ranges = [(290, 365), (1, 136)]
 
 date_format = date_format_dict[item_type] # Date format in ID string
 date_length = 15                # image_id example: "20240529_213419_83_24b2"
@@ -459,7 +467,7 @@ if date_valid :
     images_ids = get_images_ids(search_filter, item_type)
 
     if len(images_ids) > 0:
-        images_ids = rem_winter(images_ids, date_format, date_length, winter_start_day, winter_end_day)
+        images_ids = rem_winter(images_ids, date_format, date_length, exclude_ranges)
         order_url = place_order(item_type, product_bundle, images_ids, coordinates, session.auth)
 
         state = poll_for_success(order_url, session.auth)

--- a/label_inputs.py
+++ b/label_inputs.py
@@ -6,8 +6,7 @@ from rasterio.io import MemoryFile
 from rasterio.features import shapes
 from rasterio.mask import mask
 
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import numpy as np
 import glob
@@ -16,88 +15,93 @@ import os
 
 # creates a rasterio dataset in memory from a data array and corresponding CRS and transform
 # defaults to single-band datasets with nodata value of 0
-# adapted from https://medium.com/analytics-vidhya/python-for-geosciences-raster-merging-clipping-and-reprojection-with-rasterio-9f05f012b88a
 def create_dataset(data, crs, transform):
     memfile = MemoryFile()
     dataset = memfile.open(driver="GTiff", height=data.shape[0], width=data.shape[1], count=1,
                            crs=crs, transform=transform, dtype=data.dtype, nodata=0)
     dataset.write(data, 1)
-
     return dataset
 
-# takes a path for an input image and a path for a corresponding label image
-# upscales the label image to match the resolution of the input image and merges them into a 5-banded image
+# New helper that parses the date and returns a datetime object
+def parse_date_from_filename(filename):
+    """
+    Parse a date from the filename.
+    First, try "YYYY-MM-DD"; if that fails, try "YYYY_MM" (assuming the 1st day of the month).
+    """
+    regex1 = re.search(r"([0-9]{4}-[0-9]{2}-[0-9]{2})", filename)
+    if regex1:
+        try:
+            return datetime.strptime(regex1.group(0), "%Y-%m-%d")
+        except Exception:
+            pass
+    regex2 = re.search(r"([0-9]{4}_[0-9]{2})", filename)
+    if regex2:
+        try:
+            return datetime.strptime(regex2.group(0), "%Y_%m")
+        except Exception:
+            pass
+    raise ValueError(f"Filename {filename} does not contain a recognizable date format.")
+
+# Merges an input image with a corresponding label image into a 5-banded image
 def add_labels(input_path, label_path, output_path):
     with rio.open(label_path, 'r', driver='GTiff') as label, \
-         rio.open(input_path, 'r', driver='GTiff') as input:
-        # copying metadat and updating for the new band count
-        input_depth = input.count
-        input_meta = input.meta
+         rio.open(input_path, 'r', driver='GTiff') as input_data:
+        # Copy metadata and update for the new band count.
+        input_depth = input_data.count
+        input_meta = input_data.meta.copy()
         input_meta.update(count=5)
 
-        # reprojecting label layer to match the CRS and resolution of input
+        # Reproject the label layer to match the CRS and resolution of the input.
         label_reproj, label_reproj_trans = reproject(source=rio.band(label, 1),
-                                                     dst_crs = input.profile['crs'],
-                                                     dst_resolution=input.res,
+                                                     dst_crs=input_data.profile['crs'],
+                                                     dst_resolution=input_data.res,
                                                      resampling=rio.enums.Resampling.cubic_spline)
         
-        label_ds = create_dataset(label_reproj[0], input.profile['crs'], label_reproj_trans)
+        label_ds = create_dataset(label_reproj[0], input_data.profile['crs'], label_reproj_trans)
 
-        # cropping reprojected labels to input image's extent
-        extents, _ = next(shapes(np.zeros_like(input.read(1)), transform=input.profile['transform']))
-        cropped_label, crop_transf = mask(label_ds, [extents], crop=True)
+        # Crop reprojected labels to the input image's extent.
+        extents, _ = next(shapes(np.zeros_like(input_data.read(1)), transform=input_data.profile['transform']))
+        cropped_label, _ = mask(label_ds, [extents], crop=True)
 
-        # updating label layer to have no data where input image has no data
-        cropped_label_array = cropped_label[0][:input.shape[0], :input.shape[1]]
-        cropped_label_array = np.where(input.read(1) == 0, 0, cropped_label_array)
+        # Update the label layer to have no data where the input image has no data.
+        cropped_label_array = cropped_label[0][:input_data.shape[0], :input_data.shape[1]]
+        cropped_label_array = np.where(input_data.read(1) == 0, 0, cropped_label_array)
 
-        # print(reprojected_labels[0].shape)
         with rio.open(output_path, 'w', **input_meta) as dst:
-            dst.write_band(1, input.read(1))
-            dst.write_band(2, input.read(2))
-            dst.write_band(3, input.read(3))
-            dst.write_band(4, input.read(input_depth))
+            dst.write_band(1, input_data.read(1))
+            dst.write_band(2, input_data.read(2))
+            dst.write_band(3, input_data.read(3))
+            dst.write_band(4, input_data.read(input_depth))
             dst.write_band(5, cropped_label_array.astype(rio.uint16))
 
-# returns the date from a filename in YYYY-MM-DD string format
-def parse_date(filename):
-    date = re.search("([0-9]{4}\-[0-9]{2}-[0-9]{2})", filename)
-    if date:
-        return date.group(0)
-    else:
-        date = re.search("([0-9]{4}\_[0-9]{2})", filename)
-        return date.group(0)
-
 def match_labels(input_path, label_path):
-    input_files = glob.glob(input_path + "*.tif")
-    label_files = glob.glob(label_path + "*.tif")
+    input_files = glob.glob(os.path.join(input_path, "*.tif"))
+    label_files = glob.glob(os.path.join(label_path, "*.tif"))
 
-    # preparing labels for comparison
+    # Prepare labels for comparison by parsing dates to datetime objects.
     label_dict = {}
-    label_dates = []
     for label in label_files:
-        label_date = datetime.strptime(parse_date(label), "%Y_%m") + timedelta(days=14)
-        label_dates.append(label_date)
+        label_date = parse_date_from_filename(label) + timedelta(days=14)
         label_dict[label_date] = label
     
-    # comparing each input file to the label files to find the closest match
-    for input in input_files:
-        print("Input file:", os.path.basename(input))
-        input_date = datetime.strptime(parse_date(input), "%Y-%m-%d")
+    sorted_label_dates = sorted(label_dict.keys())
+    
+    # Compare each input file to the label files to find the closest match.
+    for input_file in input_files:
+        print("Input file:", os.path.basename(input_file))
+        input_date = parse_date_from_filename(input_file)
+        closest_date = min(sorted_label_dates, key=lambda d: abs(d - input_date))
+        print("Matching label:", os.path.basename(label_dict[closest_date]))
         out_name = input_date.strftime("%Y-%m-%d") + "_labeled.tif"
-        out_path = "data/labeled_inputs/" + out_name
-        # checking if file already exists
+        out_path = os.path.join("data/labeled_inputs/", out_name)
         if os.path.exists(out_path):
             print("Labeled file already exists at:", out_path)
             print()
             continue
-        
-        date_diffs = [abs(label_date - input_date) for label_date in label_dates]
-        closest_date = label_dates[date_diffs.index(min(date_diffs))]
-        print("Matching label:", os.path.basename(label_dict[closest_date]))
-        print("Merging as: {}...".format(out_name), end="")
-        add_labels(input, label_dict[closest_date], out_path)
+        print("Merging as:", out_name, end="...")
+        add_labels(input_file, label_dict[closest_date], out_path)
         print("DONE")
         print()
 
-match_labels("data/input/", "data/labels/")
+if __name__ == "__main__":
+    match_labels("data/input/", "data/labels/")


### PR DESCRIPTION
# Expand `rem_winter` to handle multiple date exclusion ranges
## Overview
- Extends the `rem_winter` function to skip multiple date ranges using the new `exclude_ranges` parameter.
- Helps users filter out not just one winter period but any number of seasonal or invalid time spans.