### PR TITLE
add CRS checker utility for raster and vector geospatial files

### DIFF
--- a/check_crs.py
+++ b/check_crs.py
@@ -1,0 +1,57 @@
+"""
+CRS (Coordinate Reference System) Checker
+This script checks and displays the coordinate reference system of geospatial files.
+It supports raster files (.tif, .tiff) and vector files (.shp, .geojson, .gpkg).
+
+How to use:
+1. Command line: python check_crs.py your_file.tif
+2. In Python: from check_crs import check_crs; check_crs("your_file.tif")
+"""
+
+import sys
+import os
+import rasterio
+import geopandas as gpd
+
+__all__ = ['check_crs']
+
+def check_crs(file_path, verbose=True):
+    ext = os.path.splitext(file_path)[1].lower()
+    try:
+        if ext in ['.tif', '.tiff']:
+            with rasterio.open(file_path) as src:
+                crs = src.crs
+                if verbose:
+                    print(f"Raster file: {file_path}")
+                    print(f"  CRS: {crs}\n")
+                return crs
+        elif ext in ['.shp', '.geojson', '.gpkg']:
+            gdf = gpd.read_file(file_path)
+            crs = gdf.crs
+            if verbose:
+                print(f"Vector file: {file_path}")
+                print(f"  CRS: {crs}\n")
+            return crs
+        else:
+            if verbose:
+                print(f"Unsupported file type: {file_path}")
+            return None
+    except Exception as e:
+        if verbose:
+            print(f"Error reading {file_path}: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python check_crs.py <file1> <file2> ...")
+        sys.exit(1)
+    for file_path in sys.argv[1:]:
+        check_crs(file_path, verbose=True)
+
+
+if __name__ == "__main__":
+    main() 
+
+
+

--- a/utils/check_crs.py
+++ b/utils/check_crs.py
@@ -4,8 +4,8 @@ This script checks and displays the coordinate reference system of geospatial fi
 It supports raster files (.tif, .tiff) and vector files (.shp, .geojson, .gpkg).
 
 How to use:
-1. Command line: python check_crs.py your_file.tif
-2. In Python: from check_crs import check_crs; check_crs("your_file.tif")
+1. Command line: python CoastlineExtraction/utils/check_crs.py your_file.tif
+2. In Python: from CoastlineExtraction.utils.check_crs import check_crs; check_crs("your_file.tif")
 """
 
 import sys


### PR DESCRIPTION
### Add check_crs.py Utility Script

This PR adds a reusable utility script   **utils/check_crs.py**   for checking the **Coordinate Reference System (CRS)** of geospatial files.

Instead of rewriting CRS-checking code in multiple scripts, this module can now be imported directly wherever needed.

### Features:

- It supports both raster (.tif, .tiff) and vector (.shp, .geojson, .gpkg) files.
- Helps ensure that raster and shapefile data are using the same coordinate system before processing.

### How to use it:

1. From the Command Line / Terminal
   python utils/check_crs.py path/to/your/file.tif


    To check multiple files at once:
   python utils/check_crs.py file1.tif file2.shp


2. By Importing in Python Code
from utils.check_crs import check_crs

check_crs("path/to/your/file.shp")


