### PR TITLE
Integrate load_config for dynamic path handling in ndwi_labels.py and add missing raster file

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -2,6 +2,7 @@
     "data_dir": "data",
     "image_folder": "sample_data/PlanetLabs",
     "image_files": [
+      "268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif",
       "20160909_213424_0e26_3B_AnalyticMS_SR_clip.tif",
       "20160909_213103_0e19_3B_AnalyticMS_SR_clip.tif",
       "20160909_213104_0e19_3B_AnalyticMS_SR_clip.tif",

--- a/ndwi_labels.py
+++ b/ndwi_labels.py
@@ -12,6 +12,10 @@ from matplotlib import pyplot as plt
 import numpy as np
 import cv2
 
+# Add import for config loading
+from load_config import load_config, get_image_path, get_shapefile_path
+
+
 def create_transect_points(transect_path, line_path, out_path):
     transects = gpd.read_file(transect_path)
     coastline = gpd.read_file(line_path)
@@ -222,7 +226,15 @@ boundary = {'type': 'Polygon',
                              [-162.8235626220703, 66.05622435812153]]]}
 
 
-# To Run script , you need only to change image and points path to yours.
-image_path = "D:/GSoC2024/data/input/268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif" 
-points_path = "D:/GSoC2024/data/Deering2016/Deering_transect_points_2016.shp"
+
+
+"""
+To run this script:
+Change the index number (the second argument in get_image_path and get_shapefile_path) 
+according to the file you want to process, as specified in your config_template.json.
+"""
+config = load_config()
+image_path = get_image_path(config, 0)  # 268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif
+points_path = get_shapefile_path(config, 0)  # Deering_transect_points_2016_fw.shp
+
 get_ndwi_label(image_path, points_path)


### PR DESCRIPTION
This PR introduces two key updates:

### 1.Dynamic File Path Configuration:

- Replaced hardcoded file paths in ndwi_labels.py with load_config.py utility.
- New contributors don't need to manually edit file paths inside the script.
- They can simply update the config_template.json file or change the index number to select a different image or shapefile.

**How to Use load_config for File Paths**
```
STEP 1 : Import the functions  
from load_config import load_config, get_image_path, get_shapefile_path

STEP 2: Load the config and get file paths
config = load_config()

Get the first image and shapefile (index 0)
image_path = get_image_path(config, 0)
points_path = get_shapefile_path(config, 0)

To switch to a different file, simply change the index number:
image_path = get_image_path(config, 2)   #Loads the third raster from the list
points_path = get_shapefile_path(config, 1)  #Loads the second shapefile

```

### 2.Added missing raster file
Included the file **268898_0369619_2016-10-15_0e14_BGRN_SR_clip.tif** under **sample_data/PlanetLabs/,** which is required to run the **ndwi_labels.py** file .
