### PR TITLE
Fix checkpoint saving condition in predict.py

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -92,7 +92,7 @@ def predict_batch(model, image_paths, device="cuda", threshold=0.5, checkpoint_p
             processed_images.append(image_path)
             
             # Save checkpoint every 10 images
-            if checkpoint_path and (i + 1) % 10 == 0:
+            if checkpoint_path and newly_processed % 10 == 0:
                 metadata = {
                     'device': device,
                     'threshold': threshold,


### PR DESCRIPTION
checkpoint interval now counts newly processed images, not loop index     fix#<line = 95>