### PR TITLE
Return processed images along with predictions

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -117,7 +117,7 @@ def predict_batch(model, image_paths, device="cuda", threshold=0.5, checkpoint_p
         save_checkpoint(checkpoint_path, processed_images, predictions, metadata)
         print(f"Final checkpoint saved: {len(processed_images)} images processed")
     
-    return predictions
+    return processed_images, predictions
 
 def visualize_prediction(image_path, pred_mask, save_path=None):
     """


### PR DESCRIPTION
fix: return processed_images alongside predictions from predict_batch

Previously returned only `predictions`, causing zip misalignment in main() when resuming — masks were saved to wrong image filenames.

- Before: `return predictions`
- After:  `return processed_images, predictions`

Ensures correct image-mask pairing during Alaska coastline batch inference.