### PR TITLE
fix: return processed_images with predictions to prevent mask misalig…

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -168,7 +168,7 @@ def load_trained_model(model_path, device="cuda"):
         Loaded U-Net model
     """
     model = UNet(n_channels=3, n_classes=1)
-    model.load_state_dict(torch.load(model_path, map_location=device))
+    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     model.to(device)
     return model
 


### PR DESCRIPTION
…nment

During Alaska coastal satellite image batch inference, resuming from checkpoint caused predicted masks to be saved under wrong filenames because processed_images (subset) was zipped with valid_images (full list). Returning both ensures correct image-mask pairing across interrupted runs.