### PR TITLE
add weights_only=True to torch.load for secure model loading

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -168,7 +168,7 @@ def load_trained_model(model_path, device="cuda"):
         Loaded U-Net model
     """
     model = UNet(n_channels=3, n_classes=1)
-    model.load_state_dict(torch.load(model_path, map_location=device))
+    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     model.to(device)
     return model
 


### PR DESCRIPTION
 coastline U-Net model loading used torch.load without weights_only=True,
which allows arbitrary code execution via pickle in PyTorch >= 2.0 and raises FutureWarning. Adding weights_only=True restricts deserialization to tensor data only, securing model checkpoint loading during GSoC inference runs.