### PR TITLE
unpack processed_images from predict_batch return value in main()

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -309,8 +309,7 @@ def main():
             print(f"Checkpoint path: {checkpoint_path}")
         
         print(f"Processing {len(valid_images)} images...")
-        predictions = predict_batch(model, valid_images, device, args.threshold, 
-                                  checkpoint_path, resume)
+        processed_images, predictions = predict_batch(model, valid_images, device, args.threshold, checkpoint_path, resume)
         
         # Save predictions
         for i, (image_path, pred_mask) in enumerate(zip(valid_images, predictions)):


### PR DESCRIPTION
After predict_batch was updated to return (processed_images, predictions), main() was still unpacking only predictions, causing ValueError during Alaska coastal batch inference runs. Unpacking both values ensures correct mask-to-image mapping when saving results after resumed or full batch prediction jobs