### PR TITLE
zip processed_images with predictions instead of valid_images

### DIFF
--- a/training_pipeline/predict.py
+++ b/training_pipeline/predict.py
@@ -313,7 +313,7 @@ def main():
                                   checkpoint_path, resume)
         
         # Save predictions
-        for i, (image_path, pred_mask) in enumerate(zip(valid_images, predictions)):
+        for image_path, pred_mask in zip(processed_images, predictions):
             base_name = os.path.splitext(os.path.basename(image_path))[0]
             mask_save_path = f"{base_name}_predicted_mask.png"
             Image.fromarray(pred_mask * 255).save(mask_save_path)


### PR DESCRIPTION
Zipping valid_images (full list) with predictions (subset on resume) saved masks to wrong filenames in Alaska coastal batch inference. Using processed_images ensures correct mask-to-image pairing.